### PR TITLE
Update creddump link

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ It takes time to build up collection of tools used in ctf and remember them all.
 - [bkhive and samdump2](http://sourceforge.net/projects/ophcrack/files/samdump2/) - Dump SYSTEM and SAM files
   - `apt-get install samdump2 bkhive`
 - [CFF Explorer](http://www.ntcore.com/exsuite.php) - PE Editor
-- [creddump](https://code.google.com/p/creddump/) - Dump windows credentials
+- [creddump](https://github.com/moyix/creddump) - Dump windows credentials
 - [extundelete](http://extundelete.sourceforge.net/) - Used for recovering lost data from mountable images
 - [Foremost](http://foremost.sourceforge.net/) - Extract particular kind of files using headers
   - `apt-get install foremost`


### PR DESCRIPTION
creddump moved from Google Code (which is sunsetting) to GitHub.

While the GitHub repo no longer has the full website, they will hopefully start a GitHub Page for the project, and this is the most direct link to the latest source code.
