### PR TITLE
Update the invalid link for Registry Dumper

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ It takes time to build up collection of tools used in ctf and remember them all.
 *Tools used for creating Forensics challenges*
 
 - [Dnscat](https://wiki.skullsecurity.org/Dnscat) - Hosts communication through DNS
-- [Registry Dumper](http://www.kahusecurity.com/tools/RegistryDumper_v0.1.zip) - Dump your registry
+- [Registry Dumper](http://www.kahusecurity.com/downloads/RegistryDumper_v0.2.7z) - Dump your registry
 
 ## Platforms
 


### PR DESCRIPTION
The link for Registry Dumper is invalid now.