### PR TITLE
Add link to one_gadget

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Check solve section for steganography.
 - [DLLInjector](https://github.com/OpenSecurityResearch/dllinjector) - Inject dlls in processes
 - [libformatstr](https://github.com/hellman/libformatstr) - Simplify format string exploitation.
 - [Metasploit](http://www.metasploit.com/) - Penetration testing software
+- [one_gadget](https://github.com/david942j/one_gadget) -  A tool to find the one gadget `execve('/bin/sh', NULL, NULL)` call
+  - `gem install one_gadget`
 - [Pwntools](https://github.com/Gallopsled/pwntools) - CTF Framework for writing exploits
 - [Qira](https://github.com/BinaryAnalysisPlatform/qira) - QEMU Interactive Runtime Analyser
 - [ROP Gadget](https://github.com/JonathanSalwan/ROPgadget) - Framework for ROP exploitation


### PR DESCRIPTION
one_gadget is a tool which searches for the one gadget `execve('/bin/sh', NULL, NULL)` call in libc.