### PR TITLE
Add padding-oracle-attacker

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Check solve section for steganography.
 
 - [FeatherDuster](https://github.com/nccgroup/featherduster) - An automated, modular cryptanalysis tool
 - [Hash Extender](https://github.com/iagox86/hash_extender) - A utility tool for performing hash length extension attacks
+- [padding-oracle-attacker](https://github.com/KishanBagaria/padding-oracle-attacker) - A CLI tool to execute padding oracle attacks
 - [PkCrack](https://www.unix-ag.uni-kl.de/~conrad/krypto/pkcrack.html) - A tool for Breaking PkZip-encryption
 - [RSACTFTool](https://github.com/Ganapati/RsaCtfTool) - A tool for recovering RSA private key with various attack
 - [RSATool](https://github.com/ius/rsatool) - Generate private key with knowledge of p and q


### PR DESCRIPTION
[padding-oracle-attacker](https://github.com/KishanBagaria/padding-oracle-attacker) is a CLI tool and library to execute padding oracle attacks easily.

CTFs frequently contain challenges that involve a padding oracle attack.
