### PR TITLE
Adding Aperisolve in Steganography section

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Check solve section for steganography.
 
 *Tools used for solving Steganography challenges*
 
+- [AperiSolve](https://aperisolve.fr/) - Aperi'Solve is a platform which performs layer analysis on image (open-source)
 - [Convert](http://www.imagemagick.org/script/convert.php) - Convert images b/w formats and apply filters
 - [Exif](http://manpages.ubuntu.com/manpages/trusty/man1/exif.1.html) - Shows EXIF information in JPEG files
 - [Exiftool](https://linux.die.net/man/1/exiftool) - Read and write meta information in files


### PR DESCRIPTION
You can also find the git repository of the AperiSolve project at [this link](https://github.com/Zeecka/AperiSolve).