### PR TITLE
Add MotherFucking-CTF to the list of CTFs platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ It takes time to build up collection of tools used in CTF and remember them all.
 - [RootTheBox](https://github.com/moloch--/RootTheBox) - A Game of Hackers (CTF Scoreboard & Game Manager).
 - [Scorebot](https://github.com/legitbs/scorebot) - Platform for CTFs by Legitbs (Defcon).
 - [SecGen](https://github.com/cliffe/SecGen) - Security Scenario Generator. Creates randomly vulnerable virtual machines.
+- [MotherFucking-CTF](https://github.com/andreafioraldi/motherfucking-ctf) - Badass lightweight plaform to host CTFs. No JS involved.
 
 ## Steganography
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ It takes time to build up collection of tools used in CTF and remember them all.
 - [Haaukins](https://github.com/aau-network-security/haaukins)- A Highly Accessible and Automated Virtualization Platform for Security Education.
 - [HackTheArch](https://github.com/mcpa-stlouis/hack-the-arch) - CTF scoring platform.
 - [Mellivora](https://github.com/Nakiami/mellivora) - A CTF engine written in PHP.
+- [MotherFucking-CTF](https://github.com/andreafioraldi/motherfucking-ctf) - Badass lightweight plaform to host CTFs. No JS involved.
 - [NightShade](https://github.com/UnrealAkama/NightShade) - A simple security CTF framework.
 - [OpenCTF](https://github.com/easyctf/openctf) - CTF in a box. Minimal setup required.
 - [PicoCTF](https://github.com/picoCTF/picoCTF) - The platform used to run picoCTF. A great framework to host any CTF.
@@ -74,7 +75,6 @@ It takes time to build up collection of tools used in CTF and remember them all.
 - [RootTheBox](https://github.com/moloch--/RootTheBox) - A Game of Hackers (CTF Scoreboard & Game Manager).
 - [Scorebot](https://github.com/legitbs/scorebot) - Platform for CTFs by Legitbs (Defcon).
 - [SecGen](https://github.com/cliffe/SecGen) - Security Scenario Generator. Creates randomly vulnerable virtual machines.
-- [MotherFucking-CTF](https://github.com/andreafioraldi/motherfucking-ctf) - Badass lightweight plaform to host CTFs. No JS involved.
 
 ## Steganography
 


### PR DESCRIPTION
MotherFucking-CTF is a super simple CTFs platform. It is often used by people to build its own custom CTF platform (just a different fronted to the MotherFucking-CTF backend).
Inspired by https://motherfuckingwebsite.com/, it aims to be simple, responsive, JavaScript free, super-fast and small enough to be used on a free dyno on Heroku without paying nothing.

Refs:
https://github.com/andreafioraldi/motherfucking-ctf
https://www.reddit.com/r/securityCTF/comments/btqlwu/a_motherfucking_ctf_platform_no_more_useless_js/