### PR TITLE
Added StegOnline to Steganography Solve section

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Check solve section for steganography.
 - [StegCracker](https://github.com/Paradoxis/StegCracker) - Steganography brute-force utility to uncover hidden data inside files.
 - [stegextract](https://github.com/evyatarmeged/stegextract) - Detect hidden files and text in images.
 - [Steghide](http://steghide.sourceforge.net/) - Hide data in various kind of images.
+- [StegOnline](https://georgeom.net/StegOnline/upload) - Conduct a wide range of image steganography operations, such as concealing/revealing files hidden within bits (open-source).
 - [Stegsolve](http://www.caesum.com/handbook/Stegsolve.jar) - Apply various steganography techniques to images.
 - [Zsteg](https://github.com/zed-0xff/zsteg/) - PNG/BMP analysis.
 


### PR DESCRIPTION
StegOnline is an online tool which, unlike other tools, allows for embedding any type of file/text within *any* bit plane(s). It also contains the more well-known steg operations, such as bit plane browsing and string viewing. It also includes a steganography checklist for users to go through during a CTF.
In terms of reliability, it has had a >99% uptime since launch.
At the time of writing, it has 49 stars on GitHub (see [here](https://github.com/Ge0rg3/StegOnline)).

https://georgeom.net/StegOnline
